### PR TITLE
Convert datapoints to vectors

### DIFF
--- a/df_to_vec.py
+++ b/df_to_vec.py
@@ -16,7 +16,7 @@ w2v_models = {
 }
 
 
-def vectorize_string(sentence, feature_length, w2v_model):
+def vectorize_string(sentence: str, feature_length: int, w2v_model: Word2Vec) -> np.ndarray:
     vector = np.zeros((feature_length, WORD_VEC_LENGTH))
 
     for i, word in enumerate(sentence.split()):
@@ -36,10 +36,10 @@ class Datapoint:
         values = "\n\t" + ",\n\t".join(values) + "\n"
         return type(self).__name__ + "(%s)" % values
 
-    def vector_length(self):
+    def vector_length(self) -> int:
         return sum(self.feature_lengths.values()) + len(self.feature_lengths.values()) - 1
 
-    def to_vec(self):
+    def to_vec(self) -> np.ndarray:
         datapoint = np.zeros((self.vector_length(), WORD_VEC_LENGTH))
 
         separator = np.ones(WORD_VEC_LENGTH)
@@ -69,7 +69,7 @@ class Datapoint:
 
         return datapoint
 
-    def to_be_predicted_to_vec(self):
+    def to_be_predicted_to_vec(self) -> np.ndarray:
         vector = np.zeros(NUMBER_OF_TYPES)
         vector[self.type] = 1
         return vector
@@ -93,7 +93,7 @@ class ParameterDatapoint(Datapoint):
             'comment': 'language'
         }
 
-    def datapoint_type_vector(self):
+    def datapoint_type_vector(self) -> np.ndarray:
         datapoint_type = np.zeros((1, WORD_VEC_LENGTH))
         datapoint_type[0][0] = 1
         return datapoint_type
@@ -127,13 +127,13 @@ class ReturnDatapoint(Datapoint):
             'parameter_names': 'code'
         }
 
-    def datapoint_type_vector(self):
+    def datapoint_type_vector(self) -> np.ndarray:
         datapoint_type = np.zeros((1, WORD_VEC_LENGTH))
         datapoint_type[0][1] = 1
         return datapoint_type
 
 
-def process_datapoints(filename: str, type: str, transformation: Callable[[Series], Datapoint]):
+def process_datapoints(filename: str, type: str, transformation: Callable[[Series], Datapoint]) -> None:
     print(f'Generating input vectors for {type} datapoints')
 
     df = pd.read_csv(filename)

--- a/df_to_vec.py
+++ b/df_to_vec.py
@@ -8,6 +8,10 @@ import os
 
 from pandas import Series
 
+OUTPUT_DIRECTORY = './output/vectors'
+PARAM_DATAPOINTS_DATAFRAME = './output/ml_inputs/_ml_param.csv'
+RETURN_DATAPOINTS_DATAFRAME = './output/ml_inputs/_ml_return.csv'
+
 VEC_LENGTH = 100
 NUMBER_OF_TYPES = 1000
 
@@ -214,28 +218,26 @@ def process_datapoints(filename: str, type: str, transformation: Callable[[Serie
     datapoints = df.apply(transformation, axis=1)
 
     datapoints_result_x = np.stack(datapoints.apply(lambda x: x.to_vec()), axis=0)
-    np.save(os.path.join(output_directory, type + '_datapoints_x'), datapoints_result_x)
+    np.save(os.path.join(OUTPUT_DIRECTORY, type + '_datapoints_x'), datapoints_result_x)
     datapoints_result_y = np.stack(datapoints.apply(lambda x: x.to_be_predicted_to_vec()), axis=0)
-    np.save(os.path.join(output_directory, type + '_datapoints_y'), datapoints_result_y)
+    np.save(os.path.join(OUTPUT_DIRECTORY, type + '_datapoints_y'), datapoints_result_y)
 
     return datapoints_result_x, datapoints_result_y
 
 
 if __name__ == '__main__':
-    output_directory = './output/vectors'
-
-    if not os.path.isdir(output_directory):
-        os.mkdir(output_directory)
+    if not os.path.isdir(OUTPUT_DIRECTORY):
+        os.mkdir(OUTPUT_DIRECTORY)
 
     # Process parameter datapoints
     param_datapoints_result_x, param_datapoints_result_y = process_datapoints(
-        './output/ml_inputs/_ml_param.csv',
+        PARAM_DATAPOINTS_DATAFRAME,
         'param',
         lambda row: ParameterDatapoint(row.arg_name, row.arg_comment, row.arg_type_enc)
     )
 
     return_datapoints_result_x, return_datapoints_result_y = process_datapoints(
-        './output/ml_inputs/_ml_return.csv',
+        RETURN_DATAPOINTS_DATAFRAME,
         'return',
         lambda row: ReturnDatapoint(row['name'], row.func_descr if row.func_descr is str else row.docstring,
                                     row.return_descr, row.return_expr, row.arg_names_str, row.return_type_enc),

--- a/df_to_vec.py
+++ b/df_to_vec.py
@@ -1,0 +1,199 @@
+import random
+import time
+
+import pandas as pd
+from gensim.models import Word2Vec
+import numpy as np
+import os
+
+WORD_VEC_LENGTH = 100
+NUMBER_OF_TYPES = 1000
+
+w2v_models = {
+    'code': Word2Vec.load('resources/word2vec_model_code.bin'),
+    'language': Word2Vec.load('resources/word2vec_model_language.bin')
+}
+
+
+# NL2Type code
+def vectorize_string(text, feature_length, w2v_model):
+    text_vec = np.zeros((feature_length, WORD_VEC_LENGTH))
+    if text == 'unknown':
+        return text_vec
+    count = 0
+    for word in text.split():
+        if count >= feature_length:
+            return text_vec
+        try:
+            text_vec[count] = w2v_model.wv[word]
+        except KeyError:
+            pass
+        count += 1
+
+    return text_vec
+# /NL2Type code
+
+class Datapoint:
+    def __repr__(self) -> str:
+        values = list(map(lambda kv: kv[0] + ': ' + repr(kv[1]), self.__dict__.items()))
+        values = "\n\t" + ",\n\t".join(values) + "\n"
+        return type(self).__name__ + "(%s)" % values
+
+    def vector_length(self):
+        return sum(self.features.values()) + len(self.features.values()) - 1
+
+    def to_vec(self):
+        datapoint = np.zeros((self.vector_length(), WORD_VEC_LENGTH))
+
+        separator = np.ones(WORD_VEC_LENGTH)
+
+        position = 0
+        for feature, feature_length in self.features.items():
+
+            if self.feature_types[feature] == 'datapoint_type':
+                datapoint[position] = self.datapoint_type_vector()
+                position += 1
+
+            if self.feature_types[feature] == 'code' or self.feature_types[feature] == 'language':
+                vectorized_feature = vectorize_string(
+                    self.__dict__[feature],
+                    feature_length,
+                    w2v_models[self.feature_types[feature]]
+                )
+
+                for word in vectorized_feature:
+                    datapoint[position] = word
+                    position += 1
+
+            # Add separator after each feature
+            if position < len(datapoint):
+                datapoint[position] = separator
+                position += 1
+
+        return datapoint
+
+    def to_be_predicted_to_vec(self):
+        vector = np.zeros(NUMBER_OF_TYPES)
+        # for now a random number
+        vector[random.randint(0, 3)] = 1
+        # vector[self.type] = 1
+        return vector
+
+
+class ParameterDatapoint(Datapoint):
+    def __init__(self, name: str, comment: str, type: int):
+        self.name = name
+        self.comment = comment
+        self.type = type
+
+        self.features = {
+            'datapoint_type': 1,
+            'name': 6,
+            'comment': 12
+        }
+
+        self.feature_types = {
+            'datapoint_type': 'datapoint_type',
+            'name': 'code',
+            'comment': 'language'
+        }
+
+    def datapoint_type_vector(self):
+        datapoint_type = np.zeros((1, WORD_VEC_LENGTH))
+        datapoint_type[0][0] = 1
+        return datapoint_type
+
+
+class ReturnDatapoint(Datapoint):
+    def __init__(self, name: str, function_comment: str, return_comment: str, return_expressions: list,
+                 parameter_names: list, type: int):
+        self.name = name
+        self.function_comment = function_comment
+        self.return_comment = return_comment
+        self.return_expressions = ' '.join(return_expressions)
+        self.parameter_names = ' '.join(parameter_names)
+        self.type = type
+
+        self.features = {
+            'datapoint_type': 1,
+            'name': 6,
+            'function_comment': 12,
+            'return_comment': 10,
+            'return_expressions': 10,  # check what this should be
+            'parameter_names': 10  # check what this should be
+        }
+
+        self.feature_types = {
+            'datapoint_type': 'datapoint_type',
+            'name': 'code',
+            'function_comment': 'language',
+            'return_comment': 'language',
+            'return_expressions': 'code',
+            'parameter_names': 'code'
+        }
+
+    def datapoint_type_vector(self):
+        datapoint_type = np.zeros((1, WORD_VEC_LENGTH))
+        datapoint_type[0][1] = 1
+        return datapoint_type
+
+
+if not os.path.isdir('./output'):
+    os.mkdir('./output')
+output_directory = os.path.join('./output', str(int(time.time())))
+os.mkdir(output_directory)
+
+df = pd.read_csv('resources/df_limited.csv')  # assumption: only functions with types
+
+df['arg_names'] = df['arg_names'].apply(lambda x: np.asarray(eval(x)))  # might not be necessary
+df['arg_descrs'] = df['arg_descrs'].apply(lambda x: np.asarray(eval(x)))
+df['return_expr'] = df['return_expr'].apply(lambda x: np.asarray(eval(x)))
+
+count = 0
+
+parameter_datapoints = []
+return_datapoints = []
+
+df = df[:2]
+
+for index, row in df.iterrows():
+    # Set function comment to be docstring if function comment is empty
+    function_comment = row.func_descr if row.func_descr is str else row.docstring
+
+    # Generate data points
+    for parameter_index, parameter_name in enumerate(row.arg_names):
+        parameter_datapoints.append(
+            ParameterDatapoint(parameter_name, row.arg_descrs[parameter_index], row.arg_types[parameter_index])
+        )
+
+    return_datapoints.append(
+        ReturnDatapoint(row['name'], function_comment, row.return_descr, row.return_expr, row.arg_names,
+                        row.return_type))
+
+# Write parameter datapoints to disk
+parameter_datapoints_result_x = np.zeros(
+    (len(parameter_datapoints), parameter_datapoints[0].vector_length(), WORD_VEC_LENGTH)
+)
+parameter_datapoints_result_y = np.zeros(
+    (len(parameter_datapoints), NUMBER_OF_TYPES)
+)
+for i, datapoint in enumerate(parameter_datapoints):
+    parameter_datapoints_result_x[i] = datapoint.to_vec()
+    parameter_datapoints_result_y[i] = datapoint.to_be_predicted_to_vec()
+
+np.save(os.path.join(output_directory, 'parameter_datapoints_x'), parameter_datapoints_result_x)
+np.save(os.path.join(output_directory, 'parameter_datapoints_y'), parameter_datapoints_result_y)
+
+# Write return datapoints to disk
+return_datapoints_result_x = np.zeros(
+    (len(return_datapoints), return_datapoints[0].vector_length(), WORD_VEC_LENGTH)
+)
+return_datapoints_result_y = np.zeros(
+    (len(return_datapoints), NUMBER_OF_TYPES)
+)
+for i, datapoint in enumerate(return_datapoints):
+    return_datapoints_result_x[i] = datapoint.to_vec()
+    return_datapoints_result_y[i] = datapoint.to_be_predicted_to_vec()
+
+np.save(os.path.join(output_directory, 'return_datapoints_result_x'), return_datapoints_result_x)
+np.save(os.path.join(output_directory, 'return_datapoints_result_y'), return_datapoints_result_y)

--- a/df_to_vec.py
+++ b/df_to_vec.py
@@ -1,6 +1,3 @@
-import random
-import sys
-import time
 from typing import Callable
 
 import pandas as pd
@@ -40,7 +37,7 @@ class Datapoint:
         return type(self).__name__ + "(%s)" % values
 
     def vector_length(self):
-        return sum(self.features.values()) + len(self.features.values()) - 1
+        return sum(self.feature_lengths.values()) + len(self.feature_lengths.values()) - 1
 
     def to_vec(self):
         datapoint = np.zeros((self.vector_length(), WORD_VEC_LENGTH))
@@ -48,7 +45,7 @@ class Datapoint:
         separator = np.ones(WORD_VEC_LENGTH)
 
         position = 0
-        for feature, feature_length in self.features.items():
+        for feature, feature_length in self.feature_lengths.items():
 
             if self.feature_types[feature] == 'datapoint_type':
                 datapoint[position] = self.datapoint_type_vector()
@@ -84,7 +81,7 @@ class ParameterDatapoint(Datapoint):
         self.comment = comment
         self.type = type
 
-        self.features = {
+        self.feature_lengths = {
             'datapoint_type': 1,
             'name': 6,
             'comment': 12
@@ -112,7 +109,7 @@ class ReturnDatapoint(Datapoint):
         self.parameter_names = parameter_names
         self.type = type
 
-        self.features = {
+        self.feature_lengths = {
             'datapoint_type': 1,
             'name': 6,
             'function_comment': 12,

--- a/df_to_vec.py
+++ b/df_to_vec.py
@@ -16,8 +16,8 @@ VEC_LENGTH = 100
 NUMBER_OF_TYPES = 1000
 
 w2v_models = {
-    'code': Word2Vec.load('resources/word2vec_model_code.bin'),
-    'language': Word2Vec.load('resources/word2vec_model_language.bin')
+    'code': Word2Vec.load('resources/w2v_code_model.bin'),
+    'language': Word2Vec.load('resources/w2v_language_model.bin')
 }
 
 
@@ -135,10 +135,10 @@ class ParameterDatapoint(Datapoint):
         return {
             'datapoint_type': 1,
             'name': 6,
-            'comment': 12,
-            'padding_0': 10,
-            'padding_1': 10,  # check what this should be
-            'padding_2': 10  # check what this should be
+            'comment': 15,
+            'padding_0': 6,
+            'padding_1': 12,
+            'padding_2': 10
         }
 
     @property
@@ -169,10 +169,10 @@ class ReturnDatapoint(Datapoint):
         return {
             'datapoint_type': 1,
             'name': 6,
-            'function_comment': 12,
-            'return_comment': 10,
-            'return_expressions': 10,  # check what this should be
-            'parameter_names': 10  # check what this should be
+            'function_comment': 15,
+            'return_comment': 6,
+            'return_expressions': 12,
+            'parameter_names': 10
         }
 
     @property

--- a/df_to_vec.py
+++ b/df_to_vec.py
@@ -130,6 +130,9 @@ class Datapoint(ABC):
 
 
 class ParameterDatapoint(Datapoint):
+    """
+    A parameter data point representing the tuple (n_p_i, c_p_i)
+    """
     @property
     def feature_lengths(self) -> Dict[str, int]:
         return {
@@ -164,6 +167,9 @@ class ParameterDatapoint(Datapoint):
 
 
 class ReturnDatapoint(Datapoint):
+    """
+    A return data point representing the tuple (n_f, c_f, r_c, r_e, n_p)
+    """
     @property
     def feature_lengths(self) -> Dict[str, int]:
         return {

--- a/df_to_vec.py
+++ b/df_to_vec.py
@@ -19,23 +19,19 @@ w2v_models = {
 }
 
 
-# NL2Type code
-def vectorize_string(text, feature_length, w2v_model):
-    text_vec = np.zeros((feature_length, WORD_VEC_LENGTH))
-    if text == 'unknown':
-        return text_vec
-    count = 0
-    for word in text.split():
-        if count >= feature_length:
-            return text_vec
+def vectorize_string(sentence, feature_length, w2v_model):
+    vector = np.zeros((feature_length, WORD_VEC_LENGTH))
+
+    for i, word in enumerate(sentence.split()):
+        if i >= feature_length:
+            break
         try:
-            text_vec[count] = w2v_model.wv[word]
+            vector[i] = w2v_model.wv[word]
         except KeyError:
             pass
-        count += 1
 
-    return text_vec
-# /NL2Type code
+    return vector
+
 
 class Datapoint:
     def __repr__(self) -> str:
@@ -144,6 +140,8 @@ def process_datapoints(filename: str, type: str, transformation: Callable[[Serie
     print(f'Generating input vectors for {type} datapoints')
 
     df = pd.read_csv(filename)
+
+    df = df[:2]
 
     if type == 'return':
         df['return_expr'] = df['return_expr'].apply(lambda x: eval(x))  ### SHOULD BE DONE IN GENERATE DF

--- a/df_to_vec.py
+++ b/df_to_vec.py
@@ -191,7 +191,7 @@ class ReturnDatapoint(Datapoint):
         self.name = name
         self.function_comment = function_comment
         self.return_comment = return_comment
-        self.return_expressions = ' '.join(return_expressions)  ### SHOULD BE DONE IN GENERATE DF
+        self.return_expressions = return_expressions
         self.parameter_names = parameter_names
         self.type = type
 
@@ -209,11 +209,6 @@ def process_datapoints(filename: str, type: str, transformation: Callable[[Serie
     print(f'Generating input vectors for {type} datapoints')
 
     df = pd.read_csv(filename)
-
-    df = df[:2]
-
-    if type == 'return':
-        df['return_expr'] = df['return_expr'].apply(lambda x: eval(x))  ### SHOULD BE DONE IN GENERATE DF
 
     datapoints = df.apply(transformation, axis=1)
 
@@ -240,7 +235,7 @@ if __name__ == '__main__':
         RETURN_DATAPOINTS_DATAFRAME,
         'return',
         lambda row: ReturnDatapoint(row['name'], row.func_descr if row.func_descr is str else row.docstring,
-                                    row.return_descr, row.return_expr, row.arg_names_str, row.return_type_enc),
+                                    row.return_descr, row.return_expr_str, row.arg_names_str, row.return_type_enc),
     )
 
     assert param_datapoints_result_x.shape[1] == return_datapoints_result_x.shape[1], \


### PR DESCRIPTION
This PR add a script that convert datapoints (output files of `generate_df.py`) to vectors (input for the RNN model).

The resulting parameter datapoint vectors look as follows:
```
datapoint_type
---SEPARATOR---
name
name
... name length 6 ...
name
---SEPARATOR---
comment
comment
... comment length 12 ...
comment
---SEPARATOR---
padding
padding
... padding length 10 ...
padding
---SEPARATOR---
padding
padding
... padding length 10 ...
padding
---SEPARATOR---
padding
padding
... padding length 10 ...
padding
```

The resulting return datapoint vectors look as follows:
```
datapoint_type
---SEPARATOR---
name
name
... name length 6 ...
name
---SEPARATOR---
function_comment
function_comment
... comment length 12 ...
function_comment
---SEPARATOR---
return_comment
return_comment
... return_comment length 10 ...
return_comment
---SEPARATOR---
return_expressions
return_expressions
... return_expressions length 10 ...
return_expressions
---SEPARATOR---
parameter_names
parameter_names
... parameter_names length 10 ...
parameter_names
```

The lengths might change after evaluation of the data (which will follow later).