### PR TITLE
Fix parameter comment preprocessing

### DIFF
--- a/nl_preprocessing.py
+++ b/nl_preprocessing.py
@@ -25,7 +25,7 @@ class NLPreprocessor:
             func_descr=self.process_sentence(function.func_descr),
             arg_names=[self.process_identifier(arg_name) for arg_name in function.arg_names],
             arg_types=function.arg_types,
-            arg_descrs=[self.process_identifier(arg_descr) for arg_descr in function.arg_descrs],
+            arg_descrs=[self.process_sentence(arg_descr) for arg_descr in function.arg_descrs],
             return_type=function.return_type,
             return_expr=[self.process_identifier(expr.replace('return ', '')) for expr in function.return_expr],
             return_descr=self.process_sentence(function.return_descr)


### PR DESCRIPTION
The parameter comments were processed as identifiers instead of natural language sentences.